### PR TITLE
Prevent keyboard  being pushed off screen in Hard Mode; Widened About modal description container

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -119,7 +119,9 @@
 }
 
 .indicator {
-  margin-top: 40px;
+  display: flex;
+  align-items: center;
+  flex: 1;
   text-align: center;
 }
 
@@ -134,6 +136,11 @@
   letter-spacing: 2px;
   padding: 8px 4px;
   text-transform: uppercase;
+
+  @media screen and (max-width: $xs-screen-width) {
+    font-size: 10px;
+    padding: 6px 3px;
+  }
 }
 
 ::ng-deep {

--- a/src/app/components/about/about.component.scss
+++ b/src/app/components/about/about.component.scss
@@ -25,8 +25,12 @@
 }
 
 .about-desc {
-  flex: 1;
+  flex: 1.5;
   margin-left: 10px;
+}
+
+.about-thanks-desc {
+  white-space: nowrap;
 }
 
 .heart-icon {

--- a/src/app/components/keyboard/keyboard.component.scss
+++ b/src/app/components/keyboard/keyboard.component.scss
@@ -4,7 +4,6 @@
   display: flex;
   justify-content: center;
   padding: 5px 5px 1vh 5px;
-  margin-top: 3vh;
 }
 
 .keyboard {


### PR DESCRIPTION
- Removed margin top from keyboard container. 
- Hard Mode indicator container now flexbox, which grows to meet available space.
- Widen the About modal's description column to prevent word wrapping on smaller devices.