### PR TITLE
Restore missing borders

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -130,7 +130,8 @@
   background: none;
   border-bottom: 1px dotted $color-grey-500;
   border-top: 1px dotted $color-grey-500;
-  border: none;
+  border-left: none;
+  border-right: none;
   color: $color-light-blue;
   display: inline-block;
   font-size: 14px;


### PR DESCRIPTION
- Alphabetizing of CSS properties moved border:none below other border rules. Rewrote to be more specific. 